### PR TITLE
Support deploy secrets fallback to repository variables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,20 +22,65 @@ jobs:
         id: secrets
         shell: bash
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
-          ENV_FILE: ${{ secrets.ENV_FILE }}
-          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_HOST_SECRET: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_HOST_VAR: ${{ vars.DEPLOY_HOST }}
+          DEPLOY_PATH_SECRET: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_PATH_VAR: ${{ vars.DEPLOY_PATH }}
+          DEPLOY_USER_SECRET: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_USERNAME_SECRET: ${{ secrets.DEPLOY_USERNAME }}
+          DEPLOY_USER_VAR: ${{ vars.DEPLOY_USER }}
+          DEPLOY_USERNAME_VAR: ${{ vars.DEPLOY_USERNAME }}
+          ENV_FILE_SECRET: ${{ secrets.ENV_FILE }}
+          ENV_FILE_VAR: ${{ vars.ENV_FILE }}
+          DEPLOY_SSH_KEY_SECRET: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_SSH_KEY_VAR: ${{ vars.DEPLOY_SSH_KEY }}
+          DEPLOY_PORT_SECRET: ${{ secrets.DEPLOY_PORT }}
+          DEPLOY_PORT_VAR: ${{ vars.DEPLOY_PORT }}
         run: |
           set -euo pipefail
 
+          declare -A outputs=()
           missing=()
-          for var in DEPLOY_HOST DEPLOY_PATH DEPLOY_USER ENV_FILE DEPLOY_SSH_KEY; do
-            if [ -z "${!var:-}" ]; then
-              missing+=("$var")
+
+          resolve() {
+            local candidate
+            for candidate in "$@"; do
+              if [ -n "${!candidate:-}" ]; then
+                printf '%s' "${!candidate}"
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          require() {
+            local display="$1"
+            shift
+            local output_name="${display,,}"
+            local value
+            if value="$(resolve "$@")"; then
+              outputs["$output_name"]="$value"
+            else
+              missing+=("$display")
             fi
-          done
+          }
+
+          optional() {
+            local display="$1"
+            shift
+            local output_name="${display,,}"
+            local value
+            if value="$(resolve "$@")"; then
+              outputs["$output_name"]="$value"
+            fi
+          }
+
+          require DEPLOY_HOST DEPLOY_HOST_SECRET DEPLOY_HOST_VAR
+          require DEPLOY_PATH DEPLOY_PATH_SECRET DEPLOY_PATH_VAR
+          require DEPLOY_USER DEPLOY_USER_SECRET DEPLOY_USERNAME_SECRET DEPLOY_USER_VAR DEPLOY_USERNAME_VAR
+          require ENV_FILE ENV_FILE_SECRET ENV_FILE_VAR
+          require DEPLOY_SSH_KEY DEPLOY_SSH_KEY_SECRET DEPLOY_SSH_KEY_VAR
+          optional DEPLOY_PORT DEPLOY_PORT_SECRET DEPLOY_PORT_VAR
 
           if [ "${#missing[@]}" -ne 0 ]; then
             printf '::warning::Skipping deploy because secrets are missing: %s\n' "${missing[*]}"
@@ -43,6 +88,27 @@ jobs:
           else
             echo "missing=false" >> "$GITHUB_OUTPUT"
           fi
+
+          for key in DEPLOY_HOST DEPLOY_PATH DEPLOY_USER DEPLOY_SSH_KEY DEPLOY_PORT ENV_FILE; do
+            local_name="${key,,}"
+            value="${outputs[$local_name]:-}"
+            if [ -z "$value" ]; then
+              continue
+            fi
+
+            case "$value" in
+              *$'\n'* )
+                {
+                  printf '%s<<EOF\n' "$local_name"
+                  printf '%s\n' "$value"
+                  printf 'EOF\n'
+                } >> "$GITHUB_OUTPUT"
+                ;;
+              * )
+                printf '%s=%s\n' "$local_name" "$value" >> "$GITHUB_OUTPUT"
+                ;;
+            esac
+          done
 
       - name: Abort deployment (secrets missing)
         if: steps.secrets.outputs.missing == 'true'
@@ -54,44 +120,44 @@ jobs:
         if: steps.secrets.outputs.missing != 'true'
         shell: bash
         env:
-          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_SSH_KEY: ${{ steps.secrets.outputs.deploy_ssh_key }}
         run: |
           set -euo pipefail
 
           mkdir -p ~/.ssh
 
           python - <<'PY'
-import base64
-import binascii
-import os
-import sys
+          import base64
+          import binascii
+          import os
+          import sys
 
-key = os.environ["DEPLOY_SSH_KEY"].strip()
+          key = os.environ["DEPLOY_SSH_KEY"].strip()
 
-if "-----BEGIN" in key:
-    data = key
-else:
-    try:
-        decoded = base64.b64decode(key, validate=True)
-    except binascii.Error as exc:
-        print("::error::DEPLOY_SSH_KEY must be a valid PEM block or a base64-encoded PEM", file=sys.stderr)
-        raise SystemExit(1) from exc
-    try:
-        data = decoded.decode("utf-8")
-    except UnicodeDecodeError as exc:
-        print("::error::Decoded DEPLOY_SSH_KEY is not valid UTF-8 text", file=sys.stderr)
-        raise SystemExit(1) from exc
+          if "-----BEGIN" in key:
+              data = key
+          else:
+              try:
+                  decoded = base64.b64decode(key, validate=True)
+              except binascii.Error as exc:
+                  print("::error::DEPLOY_SSH_KEY must be a valid PEM block or a base64-encoded PEM", file=sys.stderr)
+                  raise SystemExit(1) from exc
+              try:
+                  data = decoded.decode("utf-8")
+              except UnicodeDecodeError as exc:
+                  print("::error::Decoded DEPLOY_SSH_KEY is not valid UTF-8 text", file=sys.stderr)
+                  raise SystemExit(1) from exc
 
-if "-----BEGIN" not in data:
-    print("::error::DEPLOY_SSH_KEY does not look like a PEM-formatted key", file=sys.stderr)
-    raise SystemExit(1)
+          if "-----BEGIN" not in data:
+              print("::error::DEPLOY_SSH_KEY does not look like a PEM-formatted key", file=sys.stderr)
+              raise SystemExit(1)
 
-data = data.replace("\r\n", "\n").rstrip("\n") + "\n"
+          data = data.replace("\r\n", "\n").rstrip("\n") + "\n"
 
-path = os.path.expanduser("~/.ssh/id_deploy")
-with open(path, "w", encoding="utf-8") as fh:
-    fh.write(data)
-PY
+          path = os.path.expanduser("~/.ssh/id_deploy")
+          with open(path, "w", encoding="utf-8") as fh:
+              fh.write(data)
+          PY
 
           chmod 600 ~/.ssh/id_deploy
 
@@ -106,8 +172,8 @@ PY
       - name: Add server to known_hosts
         if: steps.secrets.outputs.missing != 'true'
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+          DEPLOY_HOST: ${{ steps.secrets.outputs.deploy_host }}
+          DEPLOY_PORT: ${{ steps.secrets.outputs.deploy_port }}
         run: |
           set -euo pipefail
 
@@ -125,10 +191,10 @@ PY
       - name: Prepare remote dir
         if: steps.secrets.outputs.missing != 'true'
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
-          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ steps.secrets.outputs.deploy_host }}
+          DEPLOY_PATH: ${{ steps.secrets.outputs.deploy_path }}
+          DEPLOY_PORT: ${{ steps.secrets.outputs.deploy_port }}
+          DEPLOY_USER: ${{ steps.secrets.outputs.deploy_user }}
         run: |
           set -euo pipefail
 
@@ -144,10 +210,10 @@ PY
       - name: Upload project
         if: steps.secrets.outputs.missing != 'true'
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
-          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ steps.secrets.outputs.deploy_host }}
+          DEPLOY_PATH: ${{ steps.secrets.outputs.deploy_path }}
+          DEPLOY_PORT: ${{ steps.secrets.outputs.deploy_port }}
+          DEPLOY_USER: ${{ steps.secrets.outputs.deploy_user }}
         run: |
           set -euo pipefail
 
@@ -166,10 +232,10 @@ PY
       - name: Write .env and compose up
         if: steps.secrets.outputs.missing != 'true'
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
-          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ steps.secrets.outputs.deploy_host }}
+          DEPLOY_PATH: ${{ steps.secrets.outputs.deploy_path }}
+          DEPLOY_PORT: ${{ steps.secrets.outputs.deploy_port }}
+          DEPLOY_USER: ${{ steps.secrets.outputs.deploy_user }}
         run: |
           set -euo pipefail
 
@@ -180,11 +246,11 @@ PY
 
           ssh "${SSH_ARGS[@]}" "$DEPLOY_USER@$DEPLOY_HOST" <<'EOSSH'
           set -euo pipefail
-          cd '${{ secrets.DEPLOY_PATH }}'
+          cd '${{ steps.secrets.outputs.deploy_path }}'
 
           # пишем .env из секрета
           cat > .env <<'EOF'
-          ${{ secrets.ENV_FILE }}
+          ${{ steps.secrets.outputs.env_file }}
           EOF
           chmod 600 .env
 


### PR DESCRIPTION
## Summary
- allow the deploy workflow to resolve credentials from either secrets or repository variables
- propagate the resolved values to subsequent steps via job outputs so deployment still runs when DEPLOY_USER is stored as a variable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db972e5f3c8321b8d1a31ba772c11e