### PR TITLE
Fix deploy workflow SSH key handling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,38 +60,28 @@ jobs:
 
           mkdir -p ~/.ssh
 
-          python - <<'PY'
-          import base64
-          import binascii
-          import os
-          import sys
+          key="$DEPLOY_SSH_KEY"
 
-          key = os.environ["DEPLOY_SSH_KEY"].strip()
+          if [[ "$key" == *"-----BEGIN"* ]]; then
+            decoded="$key"
+          else
+            if ! decoded="$(printf '%s' "$key" | base64 --decode)"; then
+              echo "::error::DEPLOY_SSH_KEY must be a valid PEM block or a base64-encoded PEM" >&2
+              exit 1
+            fi
+          fi
 
-          if "-----BEGIN" in key:
-              data = key
-          else:
-              try:
-                  decoded = base64.b64decode(key, validate=True)
-              except binascii.Error as exc:
-                  print("::error::DEPLOY_SSH_KEY must be a valid PEM block or a base64-encoded PEM", file=sys.stderr)
-                  raise SystemExit(1) from exc
-              try:
-                  data = decoded.decode("utf-8")
-              except UnicodeDecodeError as exc:
-                  print("::error::Decoded DEPLOY_SSH_KEY is not valid UTF-8 text", file=sys.stderr)
-                  raise SystemExit(1) from exc
+          if [[ "$decoded" != *"-----BEGIN"* ]]; then
+            echo "::error::DEPLOY_SSH_KEY does not look like a PEM-formatted key" >&2
+            exit 1
+          fi
 
-          if "-----BEGIN" not in data:
-              print("::error::DEPLOY_SSH_KEY does not look like a PEM-formatted key", file=sys.stderr)
-              raise SystemExit(1)
-
-          data = data.replace("\r\n", "\n").rstrip("\n") + "\n"
-
-          path = os.path.expanduser("~/.ssh/id_deploy")
-          with open(path, "w", encoding="utf-8") as fh:
-              fh.write(data)
-          PY
+          cleaned="$(printf '%s' "$decoded" | tr -d '\r')"
+          if [[ "$cleaned" == *$'\n' ]]; then
+            printf '%s' "$cleaned" > ~/.ssh/id_deploy
+          else
+            printf '%s\n' "$cleaned" > ~/.ssh/id_deploy
+          fi
 
           chmod 600 ~/.ssh/id_deploy
 


### PR DESCRIPTION
## Summary
- replace inline Python in the deploy workflow with portable shell logic
- ensure DEPLOY_SSH_KEY secrets are validated and written with normalized newlines before use

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db9f495b0c8321a601f2f6a166a67b