### PR TITLE
Store bot dependencies in context

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -2,11 +2,13 @@
 
 from .config import BotConfig, load_config
 from .db import Base, ProfileModel, ProfileRepository
+from .main import attach_bot_context
 
 __all__ = [
     "Base",
     "BotConfig",
     "ProfileModel",
     "ProfileRepository",
+    "attach_bot_context",
     "load_config",
 ]


### PR DESCRIPTION
## Summary
- store configuration and profile repository inside the bot context and expose a helper for reuse
- adjust accessors and handlers to pull dependencies from the bot instance and report user-friendly errors
- update the main entrypoint to attach context data when bootstrapping the bot

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68dba9456a348321af0f25333ea958d1