### PR TITLE
Fix Alembic path resolution for bot start

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 
 import asyncio
 import os
-import sys  # noqa: F401 - used implicitly by logging config
+import sys
 from logging.config import fileConfig
 
 from alembic import context
 from sqlalchemy import pool
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
 
 from bot.db import Base
 


### PR DESCRIPTION
## Summary
- ensure the migrations environment script adds the project root to sys.path before importing bot modules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbaf942f0c8321a72e6864ae6c4ed9