### PR TITLE
Add logging for debugging profile persistence

### DIFF
--- a/bot/db.py
+++ b/bot/db.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import BigInteger, String, Text, select
@@ -13,6 +14,9 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 if TYPE_CHECKING:  # pragma: no cover - only for type checking
     from .main import Profile
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class Base(DeclarativeBase):
@@ -108,8 +112,14 @@ class ProfileRepository:
                 else:
                     session.add(ProfileModel.from_profile(profile))
                 await session.commit()
+                LOGGER.info(
+                    "Profile for user_id=%s has been saved successfully", profile.user_id
+                )
             except Exception:
                 await session.rollback()
+                LOGGER.exception(
+                    "Failed to save profile for user_id=%s", profile.user_id
+                )
                 raise
 
     async def get(self, user_id: int) -> Optional["Profile"]:

--- a/bot/main.py
+++ b/bot/main.py
@@ -278,7 +278,19 @@ async def finalize_profile(message: Message, profile: Profile) -> None:
         )
         return
 
-    await repository.upsert(profile)
+    try:
+        await repository.upsert(profile)
+    except Exception as exc:  # pragma: no cover - debug assistance
+        LOGGER.exception(
+            "Error while saving profile for user_id=%s: %s", profile.user_id, exc
+        )
+        await message.answer(
+            f"Не удалось сохранить анкету. Ошибка: {exc}",
+            reply_markup=ReplyKeyboardRemove(),
+        )
+        return
+
+    LOGGER.info("Profile save completed for user_id=%s", profile.user_id)
     match = await repository.find_mutual_match(profile)
 
     if match:


### PR DESCRIPTION
## Summary
- add repository-level logging to report profile save success and failures
- guard profile finalization against database errors with detailed logs and user feedback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbbac357f08321aa16c6470fcc2802