### PR TITLE
Require configuring WEBAPP_URL for the bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Копируйте этот файл в .env и отредактируйте значения перед запуском.
 BOT_TOKEN=replace-with-real-telegram-token
+# Обязательный публичный URL, который откроется по кнопке в Telegram.
 WEBAPP_URL=http://localhost:8080
 WEBAPP_PORT=8080
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 | Переменная | Назначение |
 | --- | --- |
 | `BOT_TOKEN` | Токен Telegram-бота. Обязателен всегда. |
-| `WEBAPP_URL` | Публичный URL мини-приложения. Нужен, чтобы показать кнопку «Открыть мини-приложение». |
+| `WEBAPP_URL` | Обязателен. Публичный URL мини-приложения, который бот будет открывать по кнопке. |
 | `WEBAPP_PORT` | Порт публикации WebApp в Docker Compose (по умолчанию `8080`). |
 | `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_PORT` | Настройки PostgreSQL для Compose. |
 | `BOT_DATABASE_URL` | Строка подключения SQLAlchemy в формате `postgresql+asyncpg://`. Нужна при запуске вне Compose. |
@@ -75,8 +75,8 @@
 - `webapp` — nginx, раздаёт статический каталог `webapp/`.
 
 После запуска WebApp доступен по адресу `http://localhost:8080/`, а база — на порту,
-указанном в `.env` (по умолчанию `5432`). Не забудьте настроить `WEBAPP_URL` на публичный
-URL, если бот работает не локально.
+указанном в `.env` (по умолчанию `5432`). Бот не запустится без `WEBAPP_URL`, поэтому
+обновите переменную на публичный URL, если бот работает не локально.
 
 ## Локальный запуск без Docker
 
@@ -92,7 +92,7 @@ URL, если бот работает не локально.
    ```bash
    export BOT_TOKEN="1234567890:ABC..."
    export BOT_DATABASE_URL="postgresql+asyncpg://user:pass@localhost:5432/dating"
-   export WEBAPP_URL="https://example.com/webapp"  # необязательно
+   export WEBAPP_URL="https://example.com/webapp"
    ```
 3. Примените миграции:
    ```bash

--- a/bot/config.py
+++ b/bot/config.py
@@ -15,7 +15,7 @@ class BotConfig:
 
     token: str
     database_url: str
-    webapp_url: str | None = None
+    webapp_url: str
 
 
 def load_config() -> BotConfig:
@@ -37,8 +37,12 @@ def load_config() -> BotConfig:
         raise RuntimeError("BOT_TOKEN cannot be empty or whitespace")
 
     webapp_url = os.getenv("WEBAPP_URL")
-    if webapp_url and not webapp_url.strip():
-        raise RuntimeError("WEBAPP_URL cannot be empty if set; unset it or provide a valid URL")
+    if webapp_url is None:
+        raise RuntimeError("WEBAPP_URL environment variable is required to start the bot")
+
+    webapp_url = webapp_url.strip()
+    if not webapp_url:
+        raise RuntimeError("WEBAPP_URL cannot be empty or whitespace")
     
     database_url_raw = os.getenv("BOT_DATABASE_URL") or os.getenv("DATABASE_URL")
     if not database_url_raw:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,7 @@ def test_load_config_requires_token(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_load_config_requires_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BOT_TOKEN", "test-token")
+    monkeypatch.setenv("WEBAPP_URL", "https://example.com")
     with pytest.raises(RuntimeError, match="BOT_DATABASE_URL"):
         load_config()
 
@@ -43,6 +44,7 @@ def test_load_config_requires_database_url(monkeypatch: pytest.MonkeyPatch) -> N
 def test_load_config_validates_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BOT_TOKEN", "test-token")
     monkeypatch.setenv("BOT_DATABASE_URL", "not-a-valid-url")
+    monkeypatch.setenv("WEBAPP_URL", "https://example.com")
 
     with pytest.raises(RuntimeError, match="connection string"):
         load_config()
@@ -51,6 +53,7 @@ def test_load_config_validates_database_url(monkeypatch: pytest.MonkeyPatch) -> 
 def test_load_config_only_accepts_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BOT_TOKEN", "test-token")
     monkeypatch.setenv("BOT_DATABASE_URL", "sqlite+aiosqlite:///test.db")
+    monkeypatch.setenv("WEBAPP_URL", "https://example.com")
 
     with pytest.raises(RuntimeError, match="Only PostgreSQL"):
         load_config()
@@ -72,15 +75,28 @@ def test_load_config_rejects_empty_webapp_url(monkeypatch: pytest.MonkeyPatch) -
         "BOT_DATABASE_URL", "postgresql+asyncpg://user:pass@localhost:5432/dating"
     )
     monkeypatch.setenv("WEBAPP_URL", "   ")
-    
-    with pytest.raises(RuntimeError, match="WEBAPP_URL cannot be empty"):
+
+    with pytest.raises(RuntimeError, match="WEBAPP_URL cannot be empty or whitespace"):
+        load_config()
+
+
+def test_load_config_requires_webapp_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BOT_TOKEN", "test-token")
+    monkeypatch.setenv(
+        "BOT_DATABASE_URL", "postgresql+asyncpg://user:pass@localhost:5432/dating"
+    )
+
+    with pytest.raises(
+        RuntimeError, match="WEBAPP_URL environment variable is required"
+    ):
         load_config()
 
 
 def test_load_config_requires_database_host(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BOT_TOKEN", "test-token")
     monkeypatch.setenv("BOT_DATABASE_URL", "postgresql+asyncpg:///dating")
-    
+    monkeypatch.setenv("WEBAPP_URL", "https://example.com")
+
     with pytest.raises(RuntimeError, match="database host"):
         load_config()
 
@@ -88,7 +104,8 @@ def test_load_config_requires_database_host(monkeypatch: pytest.MonkeyPatch) -> 
 def test_load_config_requires_database_name(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BOT_TOKEN", "test-token")
     monkeypatch.setenv("BOT_DATABASE_URL", "postgresql+asyncpg://user:pass@localhost:5432/")
-    
+    monkeypatch.setenv("WEBAPP_URL", "https://example.com")
+
     with pytest.raises(RuntimeError, match="database name"):
         load_config()
 


### PR DESCRIPTION
## Summary
- ensure `load_config` requires a non-empty `WEBAPP_URL`
- add regression coverage for missing `WEBAPP_URL`
- document the requirement in README and `.env` template

## Testing
- pytest tests/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_68dbfc8308488321ba44a82fd436d450